### PR TITLE
Added missing Classification for Tank asset type

### DIFF
--- a/docs/Type_Msg_Sample.rst
+++ b/docs/Type_Msg_Sample.rst
@@ -18,7 +18,7 @@ Sample
 	{
 		"id": "TankMeasurement",
 		"version": "1.0.0.0",
-		"type": "object"
+		"type": "object",
 		"properties": {
 			"Time": {
 				"format": "date-time",
@@ -36,7 +36,8 @@ Sample
 	{
 		"id": "Tank",
 		"version": "1.0.0.0",
-		"type": "object"
+		"type": "object",
+	        "classification": "asset",
 		"properties": {
 			"Name": {
 				"type": "string",


### PR DESCRIPTION
Added missing Classification for Tank asset type. TankMeasurement value type doesnt need the classification since the default classification is "value"