### PR TITLE
Updating LinkSchema property to match rest of spec and making link type example more comprehensive

### DIFF
--- a/docs/Link_Type_Sample.rst
+++ b/docs/Link_Type_Sample.rst
@@ -23,7 +23,8 @@ Link Type Sample
 			},
 			"Target1": {
 				"type": "string",
-                        	"linkTypeId": "Tank",
+                        	"linkTypeId": "Pump",
+                        	"linkTypeVersion": "2.0.0.0"
 			}
 		}
 	}

--- a/docs/Link_Type_Sample.rst
+++ b/docs/Link_Type_Sample.rst
@@ -15,15 +15,15 @@ Link Type Sample
 			},
 			"Source": {
 				"type": "string",
-                        	"LinkSchema": "Tank"
+                        	"linkTypeId": "Tank"
 			},
 			"Target0": {
 				"type": "string",
-                        	"LinkSchema": "Tank"
+                        	"linkTypeId": "Tank"
 			},
 			"Target1": {
 				"type": "string",
-                        	"LinkSchema": "Tank"
+                        	"linkTypeId": "Tank",
 			}
 		}
 	}


### PR DESCRIPTION
Throughout the OMF spec we use the word "type" instead of "schema". This updates the spec so that the link type properties are consistent with the rest of the spec. This also changes the property from pascal case to camel case to be consistent with other properties.

The link sample did not make it clear that you can include an optional linkTypeVersion property. I also changed Target1 to a different type to make it clear that links can include targets of different types.

I chose to use "linkTypeId" and "linkTypeVersion" instead of "typeId" and "typeVersion" because the Source and TargetN properties also include a "type" property to define the data type for the property value. I felt without the link prefix it would be ambiguous that these properties refer to the link type and not the property data type.

I have not updated any of the examples. Let me know if this should be part of the pull request. 