### PR TITLE
Update docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -37,7 +37,7 @@
         ]
       }
     ],
-    "dest": "docs",
+    "dest": "_site",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
     "template": [


### PR DESCRIPTION
Drop the output files into the "_site" folder instead of "docs" folder so that the build behavior is consistent with other products. This will allow for adopting the yaml templates create for all doc pipelines