### PR TITLE
Removed flags type from the specification

### DIFF
--- a/documentation/data/data-msg-example.md
+++ b/documentation/data/data-msg-example.md
@@ -125,22 +125,21 @@ In this example, the Data message contains values Latitude and Longitude which w
 		}]
 	}
 	
-### Enum or Flags Data Message Example
+### Enum Data Message Example
 
-In this example, the Data message contains values for the ConfigurationState and DeviceStatus. These properties were defined as `flags` and `enum` types using `reftypeid`. 
+In this example, the Data message contains a value for the DeviceStatus property where the property was defined as `enum` type using `reftypeid`. 
 
 	{
 		"containerid":"TankMeasurementsV1_Tank3",		
 		"values": [{ 			
 			"Time": "2019-09-11T22:23:23.430Z",
 			"DeviceStatus": 2,
-			"ConfigurationState": 5,
 			"Pressure": 16.0,
 			"Temperature": 90.1
 		}]
 	}
 
-Numeric values must be used for properties defined as `enum` or `flags` types.
+Numeric values must be used for properties defined as `enum` type using `reftypeid`.
 	
 ### Type-less Static Data Message
 

--- a/documentation/types/enum-type.md
+++ b/documentation/types/enum-type.md
@@ -1,15 +1,13 @@
 ---
-uid: enumFlagsType
+uid: enumType
 ---
 
-# Enum and Flags Type Messages
-
-## Enum Type Message
+# Enum Type Message
 An `enum` is a type message defined by an array of name/value pairs used to create a limited set of allowed values. Once defined, the `enum` can be referenced by Properties within other Type messages.
 
 An `enum` can also be used to define a set of Data Quality values and referenced from property marked as `isquality`.
 
-### Enum Type Properties
+## Enum Type Properties
 The following keywords are used to define `enum` type definition. If a keyword is not specified the default will be used.
 
 | Name | Value |
@@ -18,7 +16,7 @@ The following keywords are used to define `enum` type definition. If a keyword i
 | `format` | Optional format of the type property. Must be from the OMF 1.2 'supported' formats table. Default: int16 |
 | `values` | Required array of name/value pairs used to create a limited set of allowed values. |
 
-### Enum values collection keywords
+## Enum values collection keywords
 To define possible values of an `enum` type, include the following keywords. If a keyword is not specified the default will be used.
 
 | Name | Value |
@@ -59,84 +57,9 @@ When referencing the `enum` type from the property that holds quality, include t
 
     { "DeviceStatus": { "reftypeid": "DeviceStatusEnum", "isquality": true } }
 
-## Flags Type Messages
-
-A `flag` is a type message defined using an array of name/value pairs used to create a limited set of allowed values where multiple states (bits) can be active at the same time. Once defined, the `flags` type can be referenced by Properties within other Type messages.
-
-### Flags Type Properties
-
-The following keywords are used to define `flags` type. If a keyword is not specified the default will be used.
-
-| Name | Value |
-| --- | --- |
-| `type` | Optional type of the Flags definition. The only currently supported type is integer. Default: integer |
-| `format` | Optional format of the type property. Defines how many flags can be defined in the values array. Must be from the OMF 1.2 'supported' formats table. Default: int32 |
-| `values` | Array of name/value pairs used to create a limited set of allowed values where multiple states (bits) can be active at the same time. Defined values must be a power of two. |
-
-### Flags values collection keywords
-To define possible values of a `flags` type, include the following keywords. If a keyword is not specified the default will be used.
-
-| Name | Value |
-| --- | --- |
-| `name` | Required unique string that describes the condition or state being represented. |
-| `value` | Required integer value associated with the given state (bit). Must be a power of two. |
-
-The example below shows `flags` type definition describing various configuration bits where multiple can be set at the same time.
-
-    { 
-		"id": "ConfigurationFlags",
-		"flags": {
-			"values": [ 
-                		{ "name":"CONFIG_BIT01", "value":1 }, 
-                		{ "name":"CONFIG_BIT02", "value":2 },
-                		{ "name":"CONFIG_BIT03", "value":4 },
-                		{ "name":"CONFIG_BIT04", "value":8 },
-                		{ "name":"CONFIG_BIT05", "value":16 },
-				{ "name":"CONFIG_BIT06", "value":1024 }  
-			] 
-		}
-	}
-
-	{ 
-		"id": "ConfigurationFlags",
-		"flags": {
-			"values": [ 
-                		{ "value":1, "name":"CONFIG_BIT01" }, 
-                		{ "value":2, "name":"CONFIG_BIT02" },
-                		{ "value":4, "name":"CONFIG_BIT03" },
-                		{ "value":8, "name":"CONFIG_BIT04" },
-                		{ "value":16,"name":"CONFIG_BIT05" },
-				{ "value":1024, "name":"CONFIG_BIT06" }  
- 			] 
-		}
-	}
-
-    	{ 
-		"id": "ConfigurationFlags",
-		"flags": {
-			"type": "Integer",
-			"format": "int32",
-			"values": [ 
-                		{ "name":"CONFIG_BIT01", "value":1 }, 
-                		{ "name":"CONFIG_BIT02", "value":2 },
-                		{ "name":"CONFIG_BIT03", "value":4 },
-                		{ "name":"CONFIG_BIT04", "value":8 },
-                		{ "name":"CONFIG_BIT05", "value":16 },
-				{ "name":"CONFIG_BIT06", "value":1024 }  
- 			] 
-		}
-	}
-
-## Flags Type Messages for Data Quality
-
-A `flags` type could be used to define a set of allowed values that represents data quality. 
-When referencing the `flags` type from the property that holds quality, include the [isquality](xref:typePropertiesAndFormats) keyword and use `reftypeid` as the data type of the property:
-
-    { "DeviceStatus": { "reftypeid": "ConfigurationFlags", "isquality": true } }
-
 ## Remarks
- - Properties referencing `flags` or `enum` type must send integer values in a data message; the use of strings is unsupported.
- - Both `flags` and `enum` can be defined as non-continuous sets.
+ - Properties referencing `enum` type must send integer values in a data message; the use of strings is unsupported.
+ - `enum` types can be defined as non-continuous sets.
 
 ## Examples
 
@@ -154,18 +77,6 @@ When referencing the `flags` type from the property that holds quality, include 
 				{ "name": "Device Failure", "value": 1 },
 				{ "name": "Device Comm Failure", "value": 2 },
 				{ "name": "Uncertain Out Limits", "value": 3 } ]
-			}
-	}, { 
-		"id": "ConfigurationFlags", 
-		"flags": {
-			"format": "int16",
-			"values": [ 
-				{ "name":"CONFIG_BIT01", "value":1 }, 
-				{ "name":"CONFIG_BIT02", "value":2 },
-				{ "name":"CONFIG_BIT03", "value":4 },
-				{ "name":"CONFIG_BIT04", "value":8 },
-				{ "name":"CONFIG_BIT05", "value":16 },
-				{ "name":"CONFIG_BIT06", "value":1024 } ] 
 			}
 	}, {
 		"id": "TankMeasurementV1",
@@ -196,9 +107,6 @@ When referencing the `flags` type from the property that holds quality, include 
 				"name": "Tank Temperature",
 				"description": "Tank Temperature in K",
 				"uom": "K"
-			},
-			"Configuration": {
-				"reftypeid": "ConfigurationFlags"
 			}
 		}
 	}]

--- a/documentation/types/type-messages.md
+++ b/documentation/types/type-messages.md
@@ -22,8 +22,7 @@ The body of a Type message consists of an array of objects. The following keywor
 | `tags` | Optional array of strings to tag the Type. |
 | `metadata` | Optional key-value pairs associated with the Type. |
 | `enum` | Optional object containing name/value pairs used to define an allowed set of values and optional type and format properties. Classification should not be set when defining an enum Type. |
-| `flags` | Optional object containing name/value pairs used to define an allowed set of values which could be combined to represent distinct value and optional type and format properties. Classification should not be set when defining a flags Type. |
-| `properties` | Key-value pairs defining the properties of a static or dynamic Type. Required unless the Type defines enum or flags. |
+| `properties` | Key-value pairs defining the properties of a static or dynamic Type. Required unless the Type defines enum. |
 
 The `id` cannot begin with the character sequence __. This has been reserved for predefined Types. Currently the only supported predefined Type 
 is [__Link](xref:linkType). The `id` property is referenced when creating instances of Types in Container and Data messages, or when 
@@ -38,13 +37,13 @@ The `basetypeid` is used to support Type inheritance and is an `id` of previousl
 If a Type is created for the sole purpose of being referenced by another Type, then `classification` is not required. If classification is not set, then instance data of that Type cannot be created.
 If the classification is set to `static` or `dynamic` then the classification of each Type must match when using `basetypeid` to define an inheritance relationship.
 
-Type messages defined as `enum` or `flags` defines a set of name/value pairs and is used for properties that have a predefined set of allowed values that could be combined in case of `flags` type. 
-The `enum` and `flags` Types are created separately so that it can be referenced by multiple properties. Refer to [Enum and flags Type](xref:enumFlagsType) for detailed information on defining an enum, and using the `reftypeid` to relate the enum property with the enum definition.
+Type message defined as `enum` defines a set of name/value pairs and is used for properties that have a predefined set of allowed values. 
+The `enum` type is created separately so that it can be referenced by multiple properties. Refer to [Enum Type](xref:enumType) for detailed information on defining an enum, and using the `reftypeid` to relate the enum property with the enum definition.
 
 The supported data types and data formats for `properties` are documented in the [Type Properties and Formats](xref:typePropertiesAndFormats) Topic. 
 
 ### Examples of Type Messages and Property Formats
 
    - [Type Properties and Formats](xref:typePropertiesAndFormats)
-   - [Enum and flags Type](xref:enumFlagsType)
+   - [Enum Type](xref:enumType)
    - [Type Message Example](xref:typeExample)

--- a/documentation/types/type-properties-and-formats.md
+++ b/documentation/types/type-properties-and-formats.md
@@ -13,7 +13,7 @@ The following keywords are used to the define the `properties` in the Type defin
 | `reftypeid` | `id` to a previously defined Type. Either `type` or `reftypeid` is required for each property. |
 | `isindex` | At least one Type Property must be designated as the index, or the Type cannot be used to create instance data. The designated isindex boolean property is used to uniquely identify discrete Data objects so that they can be updated or deleted after their initial creation. For a compound index, the order of index properties within the message determines the order within the index. |
 | `isname` | One Type Property may optionally be designated as the name by specifying a boolean value of true. Because the index must be unique across all Data objects, the isname keyword allows for multiple distinct Data objects to share a common name. |
-| `isquality` | One or more type Properties may optionally be designated as quality. These properties would then determine the overall quality of each data value. Properties designated as quality can be of any supported type and format or represented by enums or flags type. |
+| `isquality` | One or more Type Properties may optionally be designated as quality. These properties would then determine the overall quality of each data value. Properties designated as quality can be of any supported type and format or represented by enum type. |
 | `name` | Optional friendly name for the Type Property. This property can be overridden using the propertyoverrides keyword on a Container message. |
 | `description` | Optional description for the Type Property. This property can be overridden using the propertyoverrides keyword on a Container message. |
 | `uom` | Optional unit of measure for the Type Property. This property can be overridden using the propertyoverrides keyword on a Container message. |
@@ -126,7 +126,7 @@ Types without an index property cannot be used to create instance data.
 
 ### Data Quality
 
-The `isquality` keyword is used to designate particular property or properties as data quality for the Type. Properties marked with the quality keyword can have a reference to an `enum` or `flags` type or be of any supported Type and Format from the \'Supported Formats\' table above. In the example below, `isquality` keyword is used in case of property referencing an enumeration set and int16 property. This allows for capturing data quality information in its raw form.
+The `isquality` keyword is used to designate particular property or properties as data quality for the Type. Properties marked with the quality keyword can have a reference to an `enum` type or be of any supported Type and Format from the \'Supported Formats\' table above. In the example below, `isquality` keyword is used in case of property referencing an enumeration set and int16 property. This allows for capturing data quality information in its raw form.
 
 	"DeviceStatus": { "reftypeid": "DeviceStatusEnum", "isquality": true }
 

--- a/documentation/whats-new.md
+++ b/documentation/whats-new.md
@@ -10,7 +10,7 @@ Version 1.2 introduces the following incremental changes from version 1.1:
 ## Enhancements for Type messages:
 
 - Ability to support Type Inheritance using `basetypeid` defined on a [Type Message](xref:typeMessages), and Type Reuse using `reftypeid` defined on a [Property](xref:typePropertiesAndFormats) within a Type message.
-- Addition of the `enum` and `flags` keywords defined on a [Type Message](xref:typeMessages), used to create a reusable set of allowed values, and reference it as the datatype for a [Property](xref:typePropertiesAndFormats) using `reftypeid`.
+- Addition of the `enum` keyword defined on a [Type Message](xref:typeMessages), used to create a reusable set of allowed values, and reference it as the datatype for a [Property](xref:typePropertiesAndFormats) using `reftypeid`.
 - Ability to designate a property as holding data quality using `isquality` defined on a [Property](xref:typePropertiesAndFormats).
 - Support for `minimum` and `maximum` type qualifiers defined on a [Property](xref:typePropertiesAndFormats), used to restrict data values.
 - Support for `interpolation` and `extrapolation` modes defined on a [Property](xref:typePropertiesAndFormats), used to categorize the behavior of data being stored.


### PR DESCRIPTION
This PR removes flags type description and examples from the OMF specification.