### PR TITLE
Added "array" and "object" to list of types that are implicitly null.

### DIFF
--- a/documentation/types/type-properties-and-formats.md
+++ b/documentation/types/type-properties-and-formats.md
@@ -62,7 +62,7 @@ The datatype and `null` may appear in any order in the array. The default value 
 
 	"MeasurementValue": { "type": ["null", "integer"], "format": "int64" }
 	
-Values of type "string" are treated as inherently nullable thus the additional null type specification is not needed.
+Values of type "array", "object", and "string" are treated as inherently nullable thus the additional null type specification is not needed.
 	
 ### Type reuse and Inheritance
 


### PR DESCRIPTION
Update line from:

Values of type "string" are treated as inherently nullable thus the additional null type specification is not needed.

To:

Values of type "array", "object", and "string" are treated as inherently nullable thus the additional null type specification is not needed.

Array and object have the same implicitly nullable behavior as "string."