### PR TITLE
Added statement that array, object, and string types are implicitly n…

### DIFF
--- a/documentation/types/type-properties-and-formats.md
+++ b/documentation/types/type-properties-and-formats.md
@@ -45,7 +45,8 @@ defined by setting the `format` keyword, as described in the Supported Formats t
 Nullable type properties are supported by specifying an array that defines the datatype and includes the keyword `null`. 
 The datatype and `null` may appear in any order in the array. For example: 
 
-
 	"MeasurementValue": {"type": ["integer", "null"], "format": "int64"}
 
 	"MeasurementValue": {"type": ["null", "integer"], "format": "int64"}
+
+Values of type "array", "object", and "string" are treated as inherently nullable thus the additional null type specification is not needed.


### PR DESCRIPTION
Added line:

Values of type "array", "object", and "string" are treated as inherently nullable thus the additional null type specification is not needed.

The OMF 1.1 specification does not include any documentation that covers the implicit nullability of string, array, or object. Applying a strict interpretation to the 1.1 spec calls for string types to be implicitly set to a non-nullable string. 