### PR TITLE
V1.2 Simplifying Requirements for the delete action

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the documentation for OMF. You can access a readable ve
 
 ## License
 
-<a href="https://www.osisoft.com/copyright/">© 2018 - 2021 OSIsoft, LLC. All rights reserved.</a>
+<a href="https://www.osisoft.com/copyright/">© 2018 - 2022 OSIsoft, LLC. All rights reserved.</a>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/documentation/containers/container-messages.md
+++ b/documentation/containers/container-messages.md
@@ -23,13 +23,12 @@ The body of a Container message consists of an array of objects with the followi
 | `extrapolation` | Optional data mode used to override the extrapolation of a Type definition. Supported values include `all`, `none`, `forward`, and `backward`. |
 | `propertyoverrides` | Optional key-value pairs used to override properties on a Type definition. |
 
-If the `action` header value is `delete` then only `id` and `typeid` are required. All other keywords are ignored.
-
 Certain keywords defined on Type `properties` may be overridden at the container level using the optional `propertyoverrides` keyword.
 Currently supported overrides include `name`, `description`, `uom`, `minimum`, `maximum` and `interpolation`.
 Refer to the [Type Properties and Formats](xref:typePropertiesAndFormats) for a complete list of Type `properties`.
 
+If the `action` header value is `delete` then only `id` and `typeid` are required. All other keywords are ignored.
+
 ### Container Example
 
    - [Container Example](xref:containerExample)
-   - [Container Delete Example](xref:containerDeleteExample)

--- a/documentation/containers/container-messages.md
+++ b/documentation/containers/container-messages.md
@@ -23,6 +23,7 @@ The body of a Container message consists of an array of objects with the followi
 | `extrapolation` | Optional data mode used to override the extrapolation of a Type definition. Supported values include `all`, `none`, `forward`, and `backward`. |
 | `propertyoverrides` | Optional key-value pairs used to override properties on a Type definition. |
 
+If the `action` header value is `delete` then only `id` and `typeid` are required. All other keywords are ignored.
 
 Certain keywords defined on Type `properties` may be overridden at the container level using the optional `propertyoverrides` keyword.
 Currently supported overrides include `name`, `description`, `uom`, `minimum`, `maximum` and `interpolation`.
@@ -31,3 +32,4 @@ Refer to the [Type Properties and Formats](xref:typePropertiesAndFormats) for a 
 ### Container Example
 
    - [Container Example](xref:containerExample)
+   - [Container Delete Example](xref:containerDeleteExample)

--- a/documentation/containers/container-msg-example.md
+++ b/documentation/containers/container-msg-example.md
@@ -32,3 +32,15 @@ uid: containerExample
 			}
 		}
 	}]
+
+## Delete Example
+
+If the `action` header value is `delete` then only `id` and `typeid` are required. All other keywords are ignored.
+
+    [{
+		"id": "Tank1_PressureMeasurements",
+		"typeid": "TankPressure"
+	}, {
+		"id": "Tank2_PressureMeasurements",
+		"typeid": "TankPressure"
+	}]

--- a/documentation/data/data-messages.md
+++ b/documentation/data/data-messages.md
@@ -27,7 +27,6 @@ Optionally a `typeid` may be specified along with the `properties` to extend a `
 If a property is defined on the Type definition, and that property is not included in the `values` array, then a default value for that property will be assumed. Default values are specified
 in the [Supported Formats](xref:typePropertiesAndFormats) Table.
 
-
 ## Link Data Messages
 
 [__Link](xref:linkType) Data messages are used to create relationships between static Types, static and dynamic Types, and instance Data.

--- a/documentation/data/data-messages.md
+++ b/documentation/data/data-messages.md
@@ -27,6 +27,8 @@ Optionally a `typeid` may be specified along with the `properties` to extend a `
 If a property is defined on the Type definition, and that property is not included in the `values` array, then a default value for that property will be assumed. Default values are specified
 in the [Supported Formats](xref:typePropertiesAndFormats) Table.
 
+If the `action` header value is `delete` then indexed `properties` must be provided. An property is indexed if the `isindexed` keyword is `true` on the Data message Type. Secondary indexes specified on a Container are not required.
+
 ## Link Data Messages
 
 [__Link](xref:linkType) Data messages are used to create relationships between static Types, static and dynamic Types, and instance Data.

--- a/documentation/data/data-msg-example.md
+++ b/documentation/data/data-msg-example.md
@@ -172,3 +172,29 @@ In this example, the Data message defines properties for a Tank, and sends the i
 			"HourlyMaintenanceSchedule": 8
 		}]
 	}]
+
+### Delete Message Example
+
+This example assumes `PlantId` is an indexed property on the `Plant` Type and `TankName` is an indexed property on the `Tank` Type. In addition, the `Timestamp` is an indexed property associated with the `typeid` of the `Tank1_PressureMeasurements` Container.
+
+	[{
+		"typeid": "Plant",
+		"values": [{
+			"PlantId": "WTP1"
+		}]
+	}, {
+		"typeid": "Tank",
+		"values": [{
+			"TankName": "Tank1"
+		}, {
+			"TankName": "Tank2"
+		}]
+	},
+	{
+		"containerid": "Tank1_PressureMeasurements",
+		"values": [{
+			"Timestamp": "2019-09-11T22:23:23.430Z",			
+		}, {
+			"Timestamp": "2019-09-11T22:24:23.430Z",
+		}]
+	}]

--- a/documentation/types/type-message-example.md
+++ b/documentation/types/type-message-example.md
@@ -115,15 +115,26 @@ In this example we define a property of type `array`. The type of items containe
 		"classification": "static",
 		"properties": {
 			"Name": { "type": "string", "isindex": true, "isname": true },
-			"Maintenance Schedule": {
-				"type": "array",
+			"Maintenance Schedule": { "type": "array",
 				"items": {
 					"type": "string",
 					"format": "date-time"
-				}
-			},
-			"Maintenance Performed By": {
-				"type": "string"
-			}
+					}
+				},
+			"Maintenance Performed By": { "type": "string" }
 		}
-	]
+	}]
+
+### Delete Example
+
+When the `action` header value is `delete` only `id` is required. Any other values provided are ignored.
+
+	[{
+		"id": "Plant"
+	},
+	{
+		"id": "Tank"
+	},
+	{
+		"id": "TankPressure"
+	}]

--- a/documentation/types/type-messages.md
+++ b/documentation/types/type-messages.md
@@ -22,6 +22,8 @@ The body of a Type message consists of an array of objects. The following keywor
 | `extrapolation` | Optional data mode used to provide consistency when reading values. Supported values include `all`, `none`, `forward`, and `backward`. |
 | `properties` | Key-value pairs defining the properties of a static or dynamic Type. Required unless the Type defines enum. |
 
+If the `action` header value is `delete` then only `id` is required. All other keywords are ignored.
+
 The `id` cannot begin with the character sequence __. This has been reserved for predefined Types. Currently the only supported predefined Type is [__Link](xref:linkType). The `id` property is referenced when creating instances of Types in Container and Data messages, or when creating other Types that include this Type as a referenced Type.
 
 The `version` is used to supply information about the Type definition and is stored as meta data.
@@ -40,3 +42,4 @@ The supported data types and data formats for `properties` are documented in the
    - [Type Properties and Formats](xref:typePropertiesAndFormats)
    - [Enum Type](xref:enumType)
    - [Type Message Example](xref:typeExample)
+   - [Type Delete Example](xref:typeDeleteExample)

--- a/documentation/types/type-messages.md
+++ b/documentation/types/type-messages.md
@@ -4,7 +4,7 @@ uid: typeMessages
 
 # Type Messages
 
-Types are used within OMF to define the structure of data. Dynamic types are used by containers to create streams of sequentially indexed data. Static types are used by the endpoint to define non-streamed data, such as assets. Enum types are used to create an array name/value pairs to create a limited set of values for a property in a dynamic or static type. The Type messages are used to create, update and delete types. While types conntain a version, it is informational only. Multiple versions of the same type are not supported.
+Types are used within OMF to define the structure of data. Dynamic types are used by containers to create streams of sequentially indexed data. Static types are used by the endpoint to define non-streamed data, such as assets. Enum types are used to create an array name/value pairs to create a limited set of values for a property in a dynamic or static type. The Type messages are used to create, update and delete types. While types contain a version, it is informational only. Multiple versions of the same type are not supported.
 
 The body of a Type message consists of an array of objects. The following keywords are used to define a Type.
 
@@ -22,8 +22,6 @@ The body of a Type message consists of an array of objects. The following keywor
 | `extrapolation` | Optional data mode used to provide consistency when reading values. Supported values include `all`, `none`, `forward`, and `backward`. |
 | `properties` | Key-value pairs defining the properties of a static or dynamic Type. Required unless the Type defines enum. |
 
-If the `action` header value is `delete` then only `id` is required. All other keywords are ignored.
-
 The `id` cannot begin with the character sequence __. This has been reserved for predefined Types. Currently the only supported predefined Type is [__Link](xref:linkType). The `id` property is referenced when creating instances of Types in Container and Data messages, or when creating other Types that include this Type as a referenced Type.
 
 The `version` is used to supply information about the Type definition and is stored as meta data.
@@ -37,9 +35,10 @@ The `enum` type is created separately so that it can be referenced by multiple p
 
 The supported data types and data formats for `properties` are documented in the [Type Properties and Formats](xref:typePropertiesAndFormats) topic.
 
+If the `action` header value is `delete` then only `id` is required. All other keywords are ignored.
+
 ### Examples of Type Messages and Property Formats
 
    - [Type Properties and Formats](xref:typePropertiesAndFormats)
    - [Enum Type](xref:enumType)
    - [Type Message Example](xref:typeExample)
-   - [Type Delete Example](xref:typeDeleteExample)

--- a/documentation/whats-new.md
+++ b/documentation/whats-new.md
@@ -15,19 +15,21 @@ Version 1.2 introduces the following incremental changes from version 1.1:
 - Ability to designate a property as holding data quality using `isquality` defined on a [Property](xref:typePropertiesAndFormats).
 - Support for `minimum` and `maximum` type qualifiers defined on a [Property](xref:typePropertiesAndFormats).
 - Support for `interpolation` mode defined on a [Property](xref:typePropertiesAndFormats), used to categorize the behavior of data being stored in properties.
+- Simplified type delete messages requiring only `typeid`
 
 ## Enhancements for Container messages:
 
 - Ability to override values of `properties` defined by a dynamic Type using the `propertyoverrides` keyword in the [Container Message](xref:containerMessages). Currently supported property overrides include `name`, `description`, `uom`, `minimum`, `maximum`, and `interpolation`.
 - Ability to set the source of a stream of data using the `datasource` keyword defined on a [Container Message](xref:containerMessages).
 - Support for `extrapolation` mode on the container, used to categorize the behavior of data being stored and override the type 'extrapolation' setting.
+- Simplified container delete messages requiring `containerid` and `typeid`
 
 ## Enhancements for Data messages:
 
 - Addition of the `property` keyword in the [__Link](xref:linkType) Data Message used to link Types and Instances of Types to a particular property.
 - When linking to properties, the link can be defined by property to property, or defined by property to Type.
 - Support for type-less static data values to be sent in a Data Message using the new keyword [properties](xref:dataMessages) within the Data Message.
-
+- Simplified delete messages for static types which require only indexes
 
 ## Deprecated Features in OMF v1.2 specification:
 


### PR DESCRIPTION
When `action`=`delete`, OMF 1.2 messages require a minimal set of attributes. Documentation is updated to reflect this relaxed requirement. Sample messages are added to illustrate relaxed requirements for delete actions.

